### PR TITLE
dc:creator support

### DIFF
--- a/rfeed.py
+++ b/rfeed.py
@@ -519,13 +519,15 @@ class Item(Host):
 	of title or description must be present.
 	More information at http://cyber.law.harvard.edu/rss/rss.html#hrelementsOfLtitemgt
 	"""
-	def __init__(self, title = None, link = None, description = None, author = None, categories = None, comments = None, enclosure = None,
+	def __init__(self, title = None, link = None, description = None, author = None, 
+	creator = None, categories = None, comments = None, enclosure = None,
 		guid = None, pubDate = None, source = None, extensions = None):
 		""" Keyword arguments:
 		title -- Optional. The title of the item.
 		link  -- Optional. The URL of the item.
 		description -- Optional. The item synopsis.
 		author -- Optional. Email address of the author of the item.
+		creator -- Optional. Identifies the person or entity who wrote an item.
 		categories -- Optional. Includes the item in one or more categories.
 		comments -- Optional. URL of a page for comments relating to the item.
 		enclosure -- Optional. Describes a media object that is attached to the item.
@@ -544,6 +546,7 @@ class Item(Host):
 		self.link = link
 		self.description = description
 		self.author = author
+		self.creator = creator
 		self.comments = comments
 		self.enclosure = enclosure
 		self.guid = guid
@@ -566,6 +569,7 @@ class Item(Host):
 		self._write_element("link", self.link)
 		self._write_element("description", self.description)
 		self._write_element("author", self.author)
+		self._write_element("dc:creator", self.creator)
 		self._write_element("comments", self.comments)
 		self._write_element("pubDate", self._date(self.pubDate))
 
@@ -710,7 +714,7 @@ class Feed(Host):
 		handler.endElement("channel")
 
 	def _get_attributes(self):
-		attributes = {"version": "2.0"}
+		attributes = {"version": "2.0", "xmlns:dc" : "http://purl.org/dc/elements/1.1/"}
 
 		for extension in self.extensions:
 			if isinstance(extension, Extension):

--- a/tests.py
+++ b/tests.py
@@ -249,11 +249,12 @@ class ItemTestCase(BaseTestCase):
 		self.assertTrue('description' in str(cm.exception))
 
 	def test_optional_elements(self):
-		self.assertTrue(self._element('title', '123') in Feed('', '', '', items = [Item(title='123')]).rss())
-		self.assertTrue(self._element('link', '123') in Feed('', '', '', items = [Item(title = '', link='123')]).rss())
-		self.assertTrue(self._element('description', '123') in Feed('', '', '', items = [Item(description='123')]).rss())
-		self.assertTrue(self._element('author', '123') in Feed('', '', '', items = [Item(title = '', author='123')]).rss())
-		self.assertTrue(self._element('comments', '123') in Feed('', '', '', items = [Item(title = '', comments='123')]).rss())
+		self.assertTrue(self._element('title', 'My title') in Feed('', '', '', items = [Item(title='My title')]).rss())
+		self.assertTrue(self._element('link', 'http://example.com/') in Feed('', '', '', items = [Item(title = '', link='http://example.com/')]).rss())
+		self.assertTrue(self._element('description', 'My description') in Feed('', '', '', items = [Item(description='My description')]).rss())
+		self.assertTrue(self._element('author', 'email@example.com') in Feed('', '', '', items = [Item(title = '', author='email@example.com')]).rss())
+		self.assertTrue(self._element('dc:creator', 'Sample Example') in Feed('', '', '', items = [Item(title = '', creator='Sample Example')]).rss())
+		self.assertTrue(self._element('comments', 'Sample comment') in Feed('', '', '', items = [Item(title = '', comments='Sample comment')]).rss())
 		self.assertTrue(self._element('pubDate', 'Thu, 13 Nov 2014 08:00:00 GMT') in Feed('', '', '', items = [Item(title = '', pubDate = datetime.datetime(2014, 11, 13, 8, 0, 0))]).rss())
 
 	def test_categories_as_single_category_element(self):


### PR DESCRIPTION
Hello,

I've added support to the `<dc:creator>` tag in which the author name should go, since `<author>` is reserved to email.

I've run `tests.py` (passing, `Ran 73 tests in 0.030s`) and checked for W3C feed validation (passing).

Thanks,

Lorenzo