### PR TITLE
Switched from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name = "rfeed",
       version = "1.0.0",


### PR DESCRIPTION
The Python Packaging User Guide has stated that `setuptools` should be considered the [primary choice](https://packaging.python.org/key_projects/#setuptools) for Python Packaging for quite a while now. 