### PR TITLE
add support for passing short_empty_elements to rss()

### DIFF
--- a/rfeed.py
+++ b/rfeed.py
@@ -693,9 +693,9 @@ class Feed(Host):
 
 		self.items = [] if items is None else items
 
-	def rss(self):
+	def rss(self, short_empty_elements=False):
 		output = StringIO()
-		handler = saxutils.XMLGenerator(output, 'UTF-8')
+		handler = saxutils.XMLGenerator(output, 'UTF-8', short_empty_elements=short_empty_elements)
 		handler.startDocument()
 
 		handler.startElement("rss", self._get_attributes())


### PR DESCRIPTION
This will allow a user to pass the 'short_empty_elements' argument to feed.rss() and pass it through to the XMLGenerator.

It's simple, but I think fairly useful.